### PR TITLE
Create 58.gitignore

### DIFF
--- a/58.gitignore
+++ b/58.gitignore
@@ -1,0 +1,46 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Sensitive configuration files
+*.pem
+*.key
+*.crt
+
+# Build directories
+dist/
+build/
+out/
+
+# IDE specific files
+.vscode/
+.idea/
+*.swp
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+
+# Backup files
+*.bak
+*.old
+
+# Coverage directory used by tools like istanbul
+coverage/


### PR DESCRIPTION
This pull request adds a comprehensive `.gitignore` file to the repository to ensure that unnecessary files are not tracked by Git. The most important changes include excluding log files, dependency directories, environment variable files, sensitive configuration files, build directories, IDE-specific files, OS-generated files, temporary files, backup files, and coverage directories.

Exclusions in `.gitignore`:

* Log files: `logs`, `*.log`, `npm-debug.log*`
* Dependency directories: `node_modules/`, `jspm_packages/`
* Environment variable files: `.env`, `.env.local`, `.env.development.local`, `.env.test.local`, `.env.production.local`
* Sensitive configuration files: `*.pem`, `*.key`, `*.crt`
* Build directories: `dist/`, `build/`, `out/`
* IDE-specific files: `.vscode/`, `.idea/`, `*.swp`
* OS-generated files: `.DS_Store`, `Thumbs.db`
* Temporary files: `tmp/`, `temp/`, `*.tmp`
* Backup files: `*.bak`, `*.old` ([58.gitignoreR1-R46](diffhunk://#diff-eb4b61dc96f928977268471ade8e7def02345453588691edb399764bfb554ec8R1-R46)**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
