### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {}
+}


### PR DESCRIPTION
This pull request includes the addition of a new `devcontainer.json` file to the `.devcontainer` directory. The new file specifies the use of a universal development container image from Microsoft.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R4): Added a new file to specify the use of the `mcr.microsoft.com/devcontainers/universal:2` image.**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
